### PR TITLE
Fixing extraneous space in Maven Repo instructions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,7 +50,7 @@ repositories {
     jcenter()
     mavenCentral()
 
-    maven { url " https://mvnrepository.com/artifact/com.solacesystems/sol-jcsmp" }
+    maven { url "https://mvnrepository.com/artifact/com.solacesystems/sol-jcsmp" }
     // https://mvnrepository.com/artifact/com.solacesystems/sol-jcsmp
 
     


### PR DESCRIPTION
There is an additional space inside the Maven repo URL in `build.gradle` which is causing the build to fail on Windows with a `could not normalize path for file\ https://mvnrepository..."`  error.

Removing the space fixes this.

***Steps to Reproduce***

1. Clone original repo
2. Issue a build with `gradlew clean check jar`
3. Result: Build should fail with aforementioned error. 
