### PR TITLE
feat(sink): add built-in support to copy Kafka headers as Solace prop…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,13 @@ testSets {
     integrationTest
 }
 
+test {
+    useJUnit()
+}
+
 dependencies {
+    testImplementation 'junit:junit:4.12'
+    testImplementation group: 'org.mockito', name: 'mockito-all', version: '1.10.19'
     integrationTestImplementation 'junit:junit:4.12'
     integrationTestImplementation 'org.junit.jupiter:junit-jupiter-api:5.7.1'
     integrationTestImplementation 'org.junit.jupiter:junit-jupiter-engine:5.7.1'

--- a/src/main/java/com/solace/connector/kafka/connect/sink/SolaceSinkConnectorConfig.java
+++ b/src/main/java/com/solace/connector/kafka/connect/sink/SolaceSinkConnectorConfig.java
@@ -254,9 +254,19 @@ public class SolaceSinkConnectorConfig extends AbstractConfig {
         .define(SolaceSinkConstants.SOL_KERBEROS_LOGIN_CONFIG, Type.STRING, "", Importance.LOW,
             "Location of the Kerberos Login Configuration File")
 
-
+        .define(
+                SolaceSinkConstants.EMIT_KAFKA_RECORD_HEADERS_ENABLED,
+                Type.BOOLEAN,
+                false,
+                Importance.LOW,
+                "Should Kafka headers be automatically copied to Solace messages as user properties."
+        )
         ;
 
+  }
+
+  public boolean isEmitKafkaRecordHeadersEnabled() {
+    return getBoolean(SolaceSinkConstants.EMIT_KAFKA_RECORD_HEADERS_ENABLED);
   }
 
   static ConfigDef config = solaceConfigDef();

--- a/src/main/java/com/solace/connector/kafka/connect/sink/SolaceSinkConstants.java
+++ b/src/main/java/com/solace/connector/kafka/connect/sink/SolaceSinkConstants.java
@@ -132,7 +132,10 @@ public class SolaceSinkConstants {
   // Allowable values for the test sample include: NONE, DESTINATION,
   // CORRELATION_ID, CORRELATION_ID_AS_BYTES
   public static final String SOL_KAFKA_MESSAGE_KEY = "sol.kafka_message_key";
-  
+
+  // Low important Kafka headers
+  public static final String EMIT_KAFKA_RECORD_HEADERS_ENABLED = "emit.kafka.record.headers.enabled";
+
   // Low importance, offset for replay - if null, continue from last offset when was last stopped
   // value of 0 is start from beginning
   public static final String SOL_KAFKA_REPLAY_OFFSET = "sol.kafka_replay_offset";

--- a/src/main/java/com/solace/connector/kafka/connect/sink/SolaceSinkSender.java
+++ b/src/main/java/com/solace/connector/kafka/connect/sink/SolaceSinkSender.java
@@ -30,10 +30,8 @@ import com.solacesystems.jcsmp.SDTException;
 import com.solacesystems.jcsmp.SDTMap;
 import com.solacesystems.jcsmp.Topic;
 import com.solacesystems.jcsmp.XMLMessageProducer;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+
+import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
@@ -145,6 +143,8 @@ public class SolaceSinkSender {
       return;
     }
 
+    mayEnrichUserPropertiesWithKafkaRecordHeaders(record, message);
+
     if (sconfig.getBoolean(SolaceSinkConstants.SOL_DYNAMIC_DESTINATION)) {
       // Process use Dynamic destination from SolRecordProcessor
       SDTMap userMap = message.getProperties();
@@ -203,7 +203,28 @@ public class SolaceSinkSender {
       sinkTask.flush(offsets);
     }
   }
-  
+
+  /**
+   * Visible for testing.
+   */
+  void mayEnrichUserPropertiesWithKafkaRecordHeaders(final SinkRecord record,
+                                                     final BytesXMLMessage message) {
+    if (sconfig.isEmitKafkaRecordHeadersEnabled() && !record.headers().isEmpty()) {
+      final SDTMap userMap = Optional
+              .ofNullable(message.getProperties())
+              .orElseGet(JCSMPFactory.onlyInstance()::createMap);
+      record.headers().forEach(header -> {
+        try {
+          userMap.putObject(header.key(), header.value());
+        } catch (SDTException e) {
+          // Re-throw the exception because there is nothing else to do - usually that exception should not happen.
+          throw new RuntimeException("Failed to add object message property from kafka record-header", e);
+        }
+      });
+      message.setProperties(userMap);
+    }
+  }
+
   /**
    * Commit Solace and Kafka records.
    * @return Boolean Status

--- a/src/test/java/com/solace/connector/kafka/connect/sink/SolaceSinkSenderTest.java
+++ b/src/test/java/com/solace/connector/kafka/connect/sink/SolaceSinkSenderTest.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.solace.connector.kafka.connect.sink;
+
+import com.solacesystems.jcsmp.*;
+import org.apache.kafka.common.record.TimestampType;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.header.ConnectHeaders;
+import org.apache.kafka.connect.header.Header;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.Map;
+
+import static org.junit.Assert.*;
+
+public class SolaceSinkSenderTest {
+
+    private SolSessionHandler mkSessionHandler;
+    private JCSMPSession mkJcsmpSession;
+    private SolaceSinkTask mkSolaceSinkTask;
+
+    @Before
+    public void setUp() {
+        mkSessionHandler = Mockito.mock(SolSessionHandler.class);
+        mkSolaceSinkTask = Mockito.mock(SolaceSinkTask.class);
+        mkJcsmpSession = Mockito.mock(JCSMPSession.class);
+    }
+
+    @Test
+    public void shouldAddKafkaRecordHeadersOnBytesXMLMessageWhenEnabled() throws JCSMPException {
+        // GIVEN
+        Mockito.when(mkSessionHandler.getSession()).thenReturn(mkJcsmpSession);
+        Mockito.when(mkJcsmpSession.getMessageProducer(Mockito.any())).thenReturn(null);
+
+        final SolaceSinkConnectorConfig connectorConfig = new SolaceSinkConnectorConfig(
+                Map.of(SolaceSinkConstants.EMIT_KAFKA_RECORD_HEADERS_ENABLED, "true")
+        );
+
+        final SolaceSinkSender sender = new SolaceSinkSender(
+                connectorConfig,
+                mkSessionHandler,
+                false,
+                mkSolaceSinkTask
+        );
+
+        ConnectHeaders headers = new ConnectHeaders();
+
+        headers.addString("h2", "val2");
+        headers.addString("h3", "val3");
+
+        SinkRecord record = new SinkRecord(
+                "topic",
+                0,
+                Schema.STRING_SCHEMA,
+                "key",
+                Schema.STRING_SCHEMA,
+                "value",
+                0L,
+                0L,
+                TimestampType.CREATE_TIME,
+                headers
+        );
+
+        // WHEN
+        BytesXMLMessage msg = JCSMPFactory.onlyInstance().createMessage(BytesXMLMessage.class);
+
+        SDTMap existing = JCSMPFactory.onlyInstance().createMap();
+        existing.putString("h1", "val1");
+        msg.setProperties(existing);
+        sender.mayEnrichUserPropertiesWithKafkaRecordHeaders(record, msg);
+
+        // THEN
+        SDTMap properties = msg.getProperties();
+        Assert.assertNotNull(properties);
+        Assert.assertEquals("val1", properties.getString("h1"));
+        Assert.assertEquals("val2", properties.getString("h2"));
+        Assert.assertEquals("val3", properties.getString("h3"));
+    }
+}


### PR DESCRIPTION
…s (#35)

This commit adds the config property emit.kafka.record.headers.enabled.

Resolves: #35