### PR TITLE
36 : issue#36 - add a gradle task to generate manifest.json to be com…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ src/integrationTest/resources/pubsubplus-connector-kafka*/
 
 # Local testing
 solace.properties
+manifest.json

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,8 @@
 import com.github.spotbugs.snom.SpotBugsTask
 import io.github.gradlenexus.publishplugin.InitializeNexusStagingRepository
+import groovy.json.JsonOutput
+import groovy.text.GStringTemplateEngine
+import jdk.nashorn.internal.ir.debug.JSONWriter
 
 plugins {
     id 'java-library'
@@ -76,6 +79,31 @@ spotbugs {
     reportLevel 'high' // Decrease to medium once medium errors are fixed
 }
 
+// Generate manifest.json file to be compliant with Confluent Hub client
+tasks.register("genarateKafkaConnectManifestFile") {
+
+    def manifestJsonTemplate = new File('manifest.json.template')
+    def bindMap = [
+            "FEATURE_CONFLUENT_CONTROL_CENTER_INTEGRATION_ENABLED": false,
+            "FEATURE_KAFKA_CONNECT_API_ENABLED": true,
+            "FEATURE_SINGLE_MESSAGE_TRANSFORMS_ENABLED": true,
+            "COMPONENT_NAME": project.name,
+            "RELEASE_DATE": new Date().format("yyyy-MM-dd"),
+            "VERSION": project.version
+            ]
+
+    def manifestJson = JsonOutput.unescaped(
+            new GStringTemplateEngine()
+            .createTemplate(manifestJsonTemplate)
+            .make(bindMap)
+            .toString()
+    )
+
+    new File(project.projectDir.toString() + "/manifest.json").write JsonOutput.prettyPrint(JsonOutput.toJson(manifestJson))
+}
+
+tasks.genarateKafkaConnectManifestFile.dependsOn assemble
+
 spotbugsIntegrationTest {
     enabled = false
 }
@@ -116,13 +144,13 @@ project.integrationTest {
         maxRetries = 3
     }
     afterSuite { desc, result ->
-      if (!desc.parent)
-          println("${result.resultType} " +
-              "(${result.testCount} tests, " +
-              "${result.successfulTestCount} successes, " +
-              "${result.failedTestCount} failures, " +
-              "${result.skippedTestCount} skipped)")
-      }
+        if (!desc.parent)
+            println("${result.resultType} " +
+                    "(${result.testCount} tests, " +
+                    "${result.successfulTestCount} successes, " +
+                    "${result.failedTestCount} failures, " +
+                    "${result.skippedTestCount} skipped)")
+    }
 }
 
 project.test {
@@ -167,7 +195,7 @@ task('pmdMainSarif') {
             }
 
             Provider<RegularFile> reportsDir = project.getLayout()
-                    .file(project.getProviders().provider({a -> extension.getReportsDir()}) as Provider<File>)
+                    .file(project.getProviders().provider({ a -> extension.getReportsDir() }) as Provider<File>)
             formatter(type: 'sarif', toFile: new File(reportsDir.get().getAsFile(), 'main.sarif'))
             formatter(type: 'html', toFile: new File(reportsDir.get().getAsFile(), 'main.html'))
 
@@ -230,6 +258,7 @@ distributions {
             from('doc/distribution-readme.md') { into 'doc' }
             from('LICENSE') { into 'doc' }
             from('THIRD-PARTY-LICENSES') { into 'doc' }
+            from('manifest.json') { into '' }
             into('lib') {
                 from jar
                 from(project.configurations.runtimeClasspath)
@@ -310,7 +339,7 @@ signing {
 
 tasks.withType(Sign) {
     onlyIf {
-        gradle.taskGraph.allTasks.any {task ->
+        gradle.taskGraph.allTasks.any { task ->
             task.name.startsWith("publish") && task.name.contains('Sonatype')
         }
     }

--- a/doc/distribution-readme.md
+++ b/doc/distribution-readme.md
@@ -8,4 +8,5 @@ Package directory contents:
 
 - doc: this readme and license information
 - lib: Sink Connector jar file and dependencies
-- etc: sample configuration properties and JSON file 
+- etc: sample configuration properties and JSON file
+- manifest.json: manifest file for kafka-connect to be installable via confluent-hub client

--- a/manifest.json.template
+++ b/manifest.json.template
@@ -1,0 +1,44 @@
+{
+    "author": "Solace",
+    "component_types": [
+        "sink"
+    ],
+    "description": "The PubSub+ Kafka Sink Connector consumes Kafka topic records and streams them to the PubSub+ Event Mesh as topic and/or queue data events.",
+    "documentationUrl": "https://github.com/SolaceProducts/pubsubplus-connector-kafka-sink",
+    "features": {
+        "confluent_control_center_integration": $FEATURE_CONFLUENT_CONTROL_CENTER_INTEGRATION_ENABLED,
+        "kafka_connect_api": $FEATURE_KAFKA_CONNECT_API_ENABLED,
+        "single_message_transforms": $FEATURE_SINGLE_MESSAGE_TRANSFORMS_ENABLED,
+        "supported_encodings": [
+            "any"
+        ]
+    },
+    "license": [
+        {
+            "name": "he Apache Software License, Version 2.0",
+            "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+    ],
+    "name": "$COMPONENT_NAME",
+    "owner": {
+        "name": "Solace",
+        "type": "organization",
+        "url": "https://github.com/SolaceProducts/pubsubplus-connector-kafka-sink",
+        "username": "SolaceProducts"
+    },
+    "release_date": "$RELEASE_DATE",
+    "source_url": "https://github.com/SolaceProducts/pubsubplus-connector-kafka-sink",
+    "support": {
+        "provider_name": "Solace",
+        "summary": "",
+        "url": "https://github.com/SolaceProducts/pubsubplus-connector-kafka-sink/issues"
+    },
+    "tags": [
+        "solace",
+        "kafka",
+        "sink",
+        "connector"
+    ],
+    "title": "Solace PubSub+ Connector for Kafka: Sink",
+    "version": "$VERSION"
+}


### PR DESCRIPTION
A fix for that issue : https://github.com/SolaceProducts/pubsubplus-connector-kafka-sink/issues/36

 issue#36 - add a gradle task to generate manifest.json to be complient with confulent hub cli