### PR TITLE
DATAGO-100074: Bump transitive Netty dependencies to 4.1.121.Final

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,4 @@ updates:
     allow:
       - dependency-name: "org.apache.kafka:*"
       - dependency-name: "com.solacesystems:*"
+      - dependency-name: "io.netty:*"

--- a/build.gradle
+++ b/build.gradle
@@ -62,6 +62,7 @@ dependencies {
     testImplementation 'org.apache.logging.log4j:log4j-slf4j-impl:2.18.0'
     testImplementation "org.apache.kafka:connect-api:$kafkaVersion"
 
+    implementation platform('io.netty:netty-bom:4.1.121.Final') // override Netty transitive dependencies to latest
     // Marked as compile-only to prevent conflicts with Kafka runtime, since the runtime already has the Kafka APIs.
     // See https://docs.confluent.io/platform/current/connect/devguide.html#create-an-archive
     compileOnly "org.apache.kafka:connect-api:$kafkaVersion"


### PR DESCRIPTION
Bump transitive Netty dependencies to 4.1.121.Final